### PR TITLE
Fix undefined behavior leading to crash with clang

### DIFF
--- a/src/fileutil.c
+++ b/src/fileutil.c
@@ -71,13 +71,12 @@ char *find_file(char *name, const char *path)
 	char *q;
 	char path_buf[PATH_BUF_SIZE];
 	char dir_sep[2]={DIR_SEP,0};
-	for (p=path;p;p=q+1) {
+	for (p=path;p;) {
 		q=strchr(p,LIST_SEP);
 
 		if (q) {
 			if (!prepare_path_buf(path_buf,p,q)) continue;
 		} else {
-			q--;
 			if (!prepare_path_buf(path_buf,p,p+strlen(p))) continue;
 		}
 		strcat(path_buf,dir_sep); /* always one char */
@@ -87,6 +86,11 @@ char *find_file(char *name, const char *path)
 		if (access(path_buf,0)==0) {
 			free(name); 
 			return strdup(path_buf);
+		}
+		if (q) {
+			p = q + 1;
+		} else {
+			p = NULL;
 		}
 	}
 	/* if we are here, nothing found */

--- a/src/fileutil.c
+++ b/src/fileutil.c
@@ -190,7 +190,7 @@ void list_charsets(void) {
 	int count,glob_flags=GLOB_ERR;
 #endif
 	char **ptr;
-	for (p=charset_path;p;p=q+1) {
+	for (p=charset_path;p;) {
 		q=strchr(p,LIST_SEP);
 
 		if (q) {
@@ -201,7 +201,6 @@ void list_charsets(void) {
 			strncpy(path_buf,p,q-p);
 			path_buf[q-p]=0;
 		} else {
-			q--;
 			if (strlen(p)>=PATH_BUF_SIZE) continue;
 			strcpy(path_buf,p);
 		}
@@ -248,6 +247,11 @@ void list_charsets(void) {
 		}
 		glob_flags|=GLOB_APPEND;
 #endif
+		if (q) {
+			p = q + 1;
+		} else {
+			p = NULL;
+		}
 	}
 #ifdef __MSDOS__
 	fputs("utf-8\n",stdout);


### PR DESCRIPTION
This code crashes with clang 3.4.1+, most likely due to arithmetics to null pointer, which is undefined behavior. I've fixed two apparent cases, there may be more.

PS. I'll be unavailable for 2 weeks, after that I'll try to find other cases.
PPS. FYI, there's bunch of other code fixes to catdoc in Debian, you'd probably like to review and merge them as well. Catdoc it still in high demand, and I really hope we can bring it back to shape.
